### PR TITLE
docs: corrected typo in builtin-middleware page

### DIFF
--- a/content/docs/builtin-middleware/jsx.md
+++ b/content/docs/builtin-middleware/jsx.md
@@ -127,7 +127,7 @@ app.get('/foo', (c) => {
 
 ## memo
 
-You can memorize calculated strings of the component with `memo`.
+You can memoize calculated strings of the component with `memo`.
 
 {{< tabs "import-memo" >}}
 {{< tab "npm" >}}


### PR DESCRIPTION
Documentation: replaced inadequate use of "memorize" with "memoize"