### PR TITLE
Pass Env as Bindings

### DIFF
--- a/content/docs/getting-started/cloudflare-workers.md
+++ b/content/docs/getting-started/cloudflare-workers.md
@@ -137,7 +137,7 @@ interface Env {
   PASS: string
 }
 
-const app = new Hono<Env>()
+const app = new Hono<{ Bindings: Env }>()
 
 // Access to environment values
 app.put('/upload', async (c, next) => {


### PR DESCRIPTION
`Env` should be passed as `{ Bindings: Env }`, otherwise the following ts error would occur:

![2022-09-24 15 40 42](https://user-images.githubusercontent.com/7889778/192084163-02fb567f-727c-4bc6-aea5-15cbcba7ba09.jpg)