### PR TITLE
docs(basic-auth): describe options, add recipes for multi-user auth

### DIFF
--- a/content/docs/builtin-middleware/basic-auth.md
+++ b/content/docs/builtin-middleware/basic-auth.md
@@ -5,7 +5,7 @@ title: Basic Auth Middleware
 # Basic Auth Middleware
 
 This middleware can apply Basic authentication to a specified path.
-Implementing Basic authentication with Cloudflare Workers or others is more complicated than it seems, but with this middleware, it's a breeze.
+Implementing Basic authentication with Cloudflare Workers or other platforms is more complicated than it seems, but with this middleware, it's a breeze.
 
 For more information about how the Basic auth scheme works under the hood, see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme).
 
@@ -58,7 +58,7 @@ app.get('/auth/page', (c) => {
   - The domain name of the realm, as part of the returned WWW-Authenticate challenge header. Default is `"Secure Area"`
   - _See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives_
 - `hashFunction`: Function
-  - A function to handle hashing for safe comparison of authentication tokens
+  - A function to handle hashing for safe comparison of passwords
 
 ## More Options
 
@@ -116,7 +116,7 @@ app.use(
 To use this middleware on Compute@Edge, you need to do one of two things:
 
 1. Polyfill the `crypto` module
-2. Install the `crypto-js`, and provide a `hashFunction` to the middleware. (recommended)
+2. Install the `crypto-js` package, and provide a `hashFunction` to the middleware. (recommended)
 
 Here's how to use this middleware with the `crypto-js` method:
 

--- a/content/docs/builtin-middleware/basic-auth.md
+++ b/content/docs/builtin-middleware/basic-auth.md
@@ -5,7 +5,7 @@ title: Basic Auth Middleware
 # Basic Auth Middleware
 
 This middleware can apply Basic authentication to a specified path.
-Implementing Basic authentication with Cloudflare Workers or others is more complicated than it seems, but with this, it's a snap.
+Implementing Basic authentication with Cloudflare Workers or others is more complicated than it seems, but with this middleware, it's a snap.
 
 ## Import
 
@@ -46,19 +46,58 @@ app.get('/auth/page', (c) => {
 })
 ```
 
-## Tips
+## Options
 
-For Fastly Compute@Edge, polyfill `crypto` or use `crypto-js`.
+- `username`: string - _required_
+  - The username of the user who is authenticating
+- `password`: string - _required_
+  - The password value for the provided username to authenticate against
+- `realm`: string
+  - The domain name of the realm, as part of the returned WWW-Authenticate challenge header. Default is `""`
+  - _See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives_
+- `hashFunction`: Function
+  - A function to handle hashing for safe comparison of authentication tokens
 
-Install:
+## Recipes
+
+### Using on Fastly Compute@Edge
+
+To use this middleware on Compute@Edge, you need to do one of two things:
+
+1. Polyfill the `crypto` module
+2. Install the `crypto-js`, and provide a `hashFunction` to the middleware. (recommended)
+
+Here's how to use this middleware with the `crypto-js` method:
+
+1. Install `crypto-js` via npm:
+
+{{< tabs "Install" >}}
+{{< tab "npm" >}}
 
 ```
 npm i crypto-js
 ```
 
-Override `hashFunction`:
+{{</ tab >}}
+{{< tab "Yarn" >}}
 
-```js
+```
+yarn add crypto-js
+```
+
+{{</ tab >}}
+{{< tab "pnpm" >}}
+
+```
+pnpm add crypto-js
+```
+
+{{</ tab >}}
+{{</ tabs >}}
+
+2. Provide a `hashFunction`, using the SHA-256 implementation from `crypto-js`, to the middleware:
+
+```ts
 import { SHA256 } from 'crypto-js'
 
 app.use(

--- a/content/docs/builtin-middleware/bearer-auth.md
+++ b/content/docs/builtin-middleware/bearer-auth.md
@@ -67,7 +67,7 @@ app.get('/api/page', (c) => {
 To use this middleware on Compute@Edge, you need to do one of two things:
 
 1. Polyfill the `crypto` module
-2. Install the `crypto-js`, and provide a `hashFunction` to the middleware. (recommended)
+2. Install the `crypto-js` package, and provide a `hashFunction` to the middleware. (recommended)
 
 Here's how to use this middleware with the `crypto-js` method:
 

--- a/content/docs/builtin-middleware/bearer-auth.md
+++ b/content/docs/builtin-middleware/bearer-auth.md
@@ -50,23 +50,58 @@ app.get('/api/page', (c) => {
 
 ## Options
 
-- `token` - _required_
+- `token`: string - _required_
   - The string to validate the incoming bearer token against
-- `realm`
+- `realm`: string
   - The domain name of the realm, as part of the returned WWW-Authenticate challenge header. Default is `""`
   - _See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives_
-- `prefix`
+- `prefix`: string
   - The prefix for the Authorization header value. Default is `"Bearer"`
-- `hashFunction`
+- `hashFunction`: Function
   - A function to handle hashing for safe comparison of authentication tokens
 
 ## Recipes
 
 ### Using on Fastly Compute@Edge
 
-_Fastly Compute@Edge_ requires a `hashFunction` to be defined for comparing the incoming Bearer token token with the stored value, as it doesn't provide the standard Web API implementation of the `crypto` module.
+To use this middleware on Compute@Edge, you need to do one of two things:
+
+1. Polyfill the `crypto` module
+2. Install the `crypto-js`, and provide a `hashFunction` to the middleware. (recommended)
+
+Here's how to use this middleware with the `crypto-js` method:
+
+1. Install `crypto-js` via npm:
+
+{{< tabs "Install" >}}
+{{< tab "npm" >}}
+
+```
+npm i crypto-js
+```
+
+{{</ tab >}}
+{{< tab "Yarn" >}}
+
+```
+yarn add crypto-js
+```
+
+{{</ tab >}}
+{{< tab "pnpm" >}}
+
+```
+pnpm add crypto-js
+```
+
+{{</ tab >}}
+{{</ tabs >}}
+
+2. Provide a `hashFunction`, using the SHA-256 implementation from `crypto-js`, to the middleware:
 
 ```ts
+import { SHA256 } from 'crypto-js'
+
 app.use(
   '/auth/*',
   bearerAuth({

--- a/content/docs/builtin-middleware/cache.md
+++ b/content/docs/builtin-middleware/cache.md
@@ -6,7 +6,7 @@ title: Cache Middleware
 
 The Cache middleware uses the Web Standard's [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache). It caches a given response according to the `Cache-Control` headers.
 
-The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0). See [Usage](#Usage) below for instructions on each platform.
+The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0). See [Usage](#usage) below for instructions on each platform.
 
 ## Import
 

--- a/content/docs/third-party-middleware/_index.md
+++ b/content/docs/third-party-middleware/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Third-party Middleware"
+title: 'Third-party Middleware'
 weight: 40
 ---
 
@@ -10,12 +10,10 @@ Built-in middleware does not depend on other libraries, but these can use extern
 
 Third-party middleware will be managed under honojs organization on GitHub and published in @honojs namespace. For example, there is middleware named `hello`, its repository will be `github.com/honojs/hello` and published `@honojs/hello`.
 
-
 There are third-party middleware below, now.
 The use of third-party middleware is no different from the use of other middleware.
 Enjoy these!
 
-* [GraphQL Server Middleware](https://github.com/honojs/graphql-server)
-* [Firebase Auth Middleware](https://github.com/honojs/firebase-auth)
-* [Validator Middleware](https://github.com/honojs/validator)
-* [Sentry Middleware](https://github.com/honojs/sentry)
+- [GraphQL Server Middleware](https://github.com/honojs/graphql-server)
+- [Firebase Auth Middleware](https://github.com/honojs/firebase-auth)
+- [Sentry Middleware](https://github.com/honojs/sentry)


### PR DESCRIPTION
This PR describes the Basic Auth middleware, and also fixes a few mistakes in some other pages, such as removing the deprecated 3rd party validator middleware from the list.

It also updates the types for the Bearer Auth middleware and makes the Bearer Auth `Using on Fastly Compute@Edge` recipe match the improved description from the new Basic Auth page.