### PR TITLE
docs(compress): add options for compress middleware

### DIFF
--- a/content/docs/builtin-middleware/compress.md
+++ b/content/docs/builtin-middleware/compress.md
@@ -4,30 +4,32 @@ title: Compress Middleware
 
 # Compress Middleware
 
-Compress the response body, according to `Accept-Encoding` request header.
+This middleware compresses the response body, according to `Accept-Encoding` request header.
 
 {{< hint info >}}
-Note: On Cloudflare Workers, response body will be compressed automatically.
-So, you don't have to use this middleware for Cloudflare Workers.
+Note: On Cloudflare Workers, the response body will be compressed automatically, so there need to use this middleware on Workers.
 {{< /hint >}}
 
 ## Import
 
 {{< tabs "import" >}}
 {{< tab "npm" >}}
+
 ```ts
 import { Hono } from 'hono'
 import { compress } from 'hono/compress'
 ```
+
 {{< /tab >}}
 {{< tab "Deno" >}}
+
 ```ts
 import { Hono } from 'https://deno.land/x/hono/mod.ts'
 import { compress } from 'https://deno.land/x/hono/middleware.ts'
 ```
+
 {{< /tab >}}
 {{< /tabs >}}
-
 
 ## Usage
 
@@ -36,3 +38,8 @@ const app = new Hono()
 
 app.use('*', compress())
 ```
+
+## Options
+
+- `encoding`: `'gzip'` | `'deflate'`
+  - The compression schemes to allow for response compression. Either `gzip` or `deflate`. If not defined, both are allowed and will be used based on the `Accept-Encoding` header. `gzip` is prioritized if this option is not provided and the client provides both in the `Accept-Encoding` header.

--- a/content/docs/builtin-middleware/compress.md
+++ b/content/docs/builtin-middleware/compress.md
@@ -7,7 +7,7 @@ title: Compress Middleware
 This middleware compresses the response body, according to `Accept-Encoding` request header.
 
 {{< hint info >}}
-Note: On Cloudflare Workers, the response body will be compressed automatically, so there need to use this middleware on Workers.
+Note: On Cloudflare Workers, the response body will be compressed automatically, so there is no need to use this middleware on Workers.
 {{< /hint >}}
 
 ## Import
@@ -42,4 +42,4 @@ app.use('*', compress())
 ## Options
 
 - `encoding`: `'gzip'` | `'deflate'`
-  - The compression schemes to allow for response compression. Either `gzip` or `deflate`. If not defined, both are allowed and will be used based on the `Accept-Encoding` header. `gzip` is prioritized if this option is not provided and the client provides both in the `Accept-Encoding` header.
+  - The compression scheme to allow for response compression. Either `gzip` or `deflate`. If not defined, both are allowed and will be used based on the `Accept-Encoding` header. `gzip` is prioritized if this option is not provided and the client provides both in the `Accept-Encoding` header.


### PR DESCRIPTION
This PR updates the page for the Compress middleware, adding descriptions of the options and clarifying a little about how encodings are selected for a response to the client.