### PR TITLE
Remove `npm init -y` from "Cloudflare Workers"

### DIFF
--- a/content/docs/getting-started/cloudflare-workers.md
+++ b/content/docs/getting-started/cloudflare-workers.md
@@ -29,7 +29,6 @@ npx wrangler init -y
 Install `hono` from the npm registry.
 
 ```
-npm init -y
 npm i hono
 ```
 


### PR DESCRIPTION
because the previous command `npx wrangler init -y` also creates package.json. This pull request closes #23.