### PR TITLE
docs: add Lagon docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ pygmentsCodefences = true
 
 [params]
 
-  description = "Ultrafast web framework for Cloudflare Workers, Deno, and Bun. Fast, but not only fast."
+  description = "Ultrafast web framework for Cloudflare Workers, Deno, Bun and Lagon. Fast, but not only fast."
   image = "https://honojs.dev/images/hono-title.png"
 
   # (Optional, default light) Sets color theme: light, dark or auto.

--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ type: docs
 
 # Hono
 
-Hono - _\[炎\] means flame🔥 in Japanese_ - is a small, simple, and ultrafast web framework for Cloudflare Workers, Deno, Bun, and others. Fast, but not only fast.
+Hono - _\[炎\] means flame🔥 in Japanese_ - is a small, simple, and ultrafast web framework for Cloudflare Workers, Deno, Bun, Lagon, and others. Fast, but not only fast.
 
 ```ts
 import { Hono } from 'hono'
@@ -22,7 +22,7 @@ export default app
 - **Zero-dependencies** - Using only Web Standard API. Does not depend on other npm or Deno libraries.
 - **Middleware** - Hono has built-in middleware, custom middleware, and third-party middleware. Batteries included.
 - **TypeScript** - First-class TypeScript support. Now, we've got "Types".
-- **Multi-runtime** - Works on Cloudflare Workers, Fastly Compute@Edge, Deno, Bun, or Node.js. The same code runs on all platforms.
+- **Multi-runtime** - Works on Cloudflare Workers, Fastly Compute@Edge, Deno, Bun, Lagon, or Node.js. The same code runs on all platforms.
 
 ## Benchmarks
 
@@ -150,6 +150,7 @@ Thanks to the use of the Web Standard API, Hono works on a variety of platforms.
 - Fastly Compute@Edge
 - Deno / Deno Deploy
 - Bun
+- Lagon
 - Others
 
 And using [a Node.js adaptor](https://github.com/honojs/node-server), Hono will works on Node.js.

--- a/content/docs/api/hono.md
+++ b/content/docs/api/hono.md
@@ -100,6 +100,12 @@ export default {
 }
 ```
 
+Lagon:
+
+```ts
+export const handler = app.fetch
+```
+
 ## request
 
 `request` is a useful method for testing.

--- a/content/docs/builtin-middleware/cache.md
+++ b/content/docs/builtin-middleware/cache.md
@@ -6,7 +6,7 @@ title: Cache Middleware
 
 The Cache middleware uses the Web Standard's [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache). It caches a given response according to the `Cache-Control` headers.
 
-The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0). See [Usage](#usage) below for instructions on each platform.
+The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0), but doesn't supports Lagon. See [Usage](#usage) below for instructions on each platform.
 
 ## Import
 

--- a/content/docs/builtin-middleware/compress.md
+++ b/content/docs/builtin-middleware/compress.md
@@ -7,7 +7,7 @@ title: Compress Middleware
 This middleware compresses the response body, according to `Accept-Encoding` request header.
 
 {{< hint info >}}
-Note: On Cloudflare Workers, the response body will be compressed automatically, so there is no need to use this middleware on Workers.
+Note: On Cloudflare Workers and Lagon, the response body will be compressed automatically, so there is no need to use this middleware.
 {{< /hint >}}
 
 ## Import

--- a/content/docs/builtin-middleware/serve-static.md
+++ b/content/docs/builtin-middleware/serve-static.md
@@ -8,6 +8,10 @@ This middleware distributes asset files that are put in directory specified `roo
 
 Serve Static Middleware is available only on Cloudflare Workers, Deno, and Bun.
 
+{{< hint info >}}
+Note: Lagon serves your static files using the `public` directory by default, so there is no need to use this middleware.
+{{< /hint >}}
+
 ## Import
 
 {{< tabs "import" >}}

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -1,21 +1,21 @@
 ---
-title: "Getting Started"
+title: 'Getting Started'
 weight: 10
 ---
 
 # Getting Started
 
-Hono works on multi-platforms. In this section, we introduce instructions for Cloudflare Workers, Deno, and Bun.
+Hono works on multi-platforms. In this section, we introduce instructions for Cloudflare Workers, Deno, Bun and Lagon.
 
-In all of them, TypeScript is out of the box, and development on a local environment is easy. And, we can release quickly with Cloudflare Workers. Deno also has the edge platform "*Deno Deploy*". Maybe Bun will have the edge runtime for publishing.
+In all of them, TypeScript is out of the box, and development on a local environment is easy. And, we can release quickly with Cloudflare Workers. Deno also has the edge platform "_Deno Deploy_", and Lagon offers both cloud and self-hosted options. Maybe Bun will have the edge runtime for publishing.
 
 In this section, you can know the following about each of your platforms:
 
-* Setup environments
-* Installation
-* "*Hello World*"
-* How to run
-* How to deploy
-* Testing
+- Setup environments
+- Installation
+- "_Hello World_"
+- How to run
+- How to deploy
+- Testing
 
 Let's get started!

--- a/content/docs/getting-started/lagon.md
+++ b/content/docs/getting-started/lagon.md
@@ -1,0 +1,50 @@
+---
+title: 'Lagon'
+weight: 400
+---
+
+# Lagon
+
+Lagon is an open source runtime and platform to run TypeScript and JavaScript Functions at the Edge. It's neither Node.js nor Deno.
+
+Note that some middlewares don't work or are useless.
+
+## 1. Install
+
+First, install the Lagon CLI. Please refer to [the official documentation](https://docs.lagon.app/cli#installation).
+
+Next, create an new project and install Hono:
+
+```
+npm init -y
+npm i hono
+```
+
+## 2. Hello World
+
+Create a new file `src/index.ts` and edit it:
+
+```ts
+// src/index.ts
+import { Hono } from 'hono'
+const app = new Hono()
+
+app.get('/', (c) => c.text('Hello! Hono!'))
+
+export const handler = app.fetch
+```
+
+## 3. Run
+
+Run the command.
+
+```ts
+lagon dev src/index.ts
+```
+
+Then, access `http://localhost:1234` in your browser.
+
+## Limitations
+
+- The "Cache" middleware isn't supported yet
+- The "Serve Static" middleware is useless, as Lagon serves your `public` directory by default.

--- a/content/docs/getting-started/others.md
+++ b/content/docs/getting-started/others.md
@@ -1,6 +1,6 @@
 ---
 title: 'Others'
-weight: 400
+weight: 500
 ---
 
 # Others

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -6,6 +6,7 @@ headless: true
   - [Cloudflare Workers]({{< relref "/docs/getting-started/cloudflare-workers" >}})
   - [Deno]({{< relref "/docs/getting-started/deno" >}})
   - [Bun]({{< relref "/docs/getting-started/bun" >}})
+  - [Lagon]({{< relref "/docs/getting-started/lagon" >}})
   - [Others]({{< relref "/docs/getting-started/others" >}})
 - [API]({{< relref "/docs/api" >}})
   - [Hono]({{< relref "/docs/api/hono" >}})


### PR DESCRIPTION
Hi! As discussed in https://github.com/honojs/hono/issues/734, this PR adds documentation for Lagon.

I haven't included that the ETag middleware isn't working yet because it will be fixed really soon.

Edit: ETag middleware will work in the next release of `@lagon/runtime`, see https://github.com/lagonapp/lagon/pull/405